### PR TITLE
画像アップロード機能追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /logs/*
 /tmp/*
 /vendor/*
+/webroot/upimg/*
 
 # OS generated files #
 ######################

--- a/src/Controller/Component/UploadImageComponent.php
+++ b/src/Controller/Component/UploadImageComponent.php
@@ -1,0 +1,86 @@
+<?php
+namespace App\Controller\Component;
+
+use Cake\Controller\Component;
+use Cake\Filesystem\File;
+use RuntimeException;
+
+class UploadImageComponent extends Component
+{
+    /**
+     * Undocumented function
+     *
+     * @param [type] $file アップロードしたファイル情報
+     * @param [type] $dir ファイルを保存するフォルダ
+     * @param [type] $limitFileSize 保存出来るファイルサイズの最大値
+     * @return mixed
+     */
+    public function fileUpload($file = null, $dir = null, $limitFileSize = 1024 * 1024)
+    {
+        try {
+            // ファイルを保存するフォルダ $dirの値のチェック
+            if ($dir) {
+                if (!file_exists($dir)) {
+                    throw new RuntimeException('指定のディレクトリがありません。');
+                }
+            } else {
+                throw new RuntimeException('ディレクトリの指定がありません。');
+            }
+
+            // 未定義、複数ファイル、破損攻撃のいずれかの場合は無効処理
+            if (!isset($file['error']) || is_array($file['error'])) {
+                throw new RuntimeException('Invalid parameters.');
+            }
+
+            // エラーのチェック
+            switch ($file['error']) {
+                case 0:
+                    break;
+                case UPLOAD_ERR_OK:
+                    break;
+                case UPLOAD_ERR_NO_FILE:
+                    throw new RuntimeException('No file sent.');
+                case UPLOAD_ERR_INI_SIZE:
+                case UPLOAD_ERR_FORM_SIZE:
+                    throw new RuntimeException('Exceeded filesize limit.');
+                default:
+                    throw new RuntimeException('Unknown errors.');
+            }
+
+            // ファイル情報取得
+            $fileInfo = new File($file["tmp_name"]);
+
+            // ファイルサイズのチェック
+            if ($fileInfo->size() > $limitFileSize) {
+                throw new RuntimeException('Exceeded filesize limit.');
+            }
+
+            // ファイルタイプのチェックし、拡張子を取得
+            if (false === $ext = array_search(
+                $fileInfo->mime(),
+                ['jpg' => 'image/jpeg',
+                'png' => 'image/png',
+                'gif' => 'image/gif', ],
+                true
+            )) {
+                throw new RuntimeException('Invalid file format.');
+            }
+
+            // ファイル名の生成
+            // sha1_file()でハッシュ化
+            $uploadFile = sha1_file($file["tmp_name"]) . "." . $ext;
+
+            // ファイルの移動
+            if (!move_uploaded_file($file["tmp_name"], $dir . "/" . $uploadFile)) {
+                throw new RuntimeException('Failed to move uploaded file.');
+            }
+
+            // 処理を抜けたら正常終了
+            // echo 'File is uploaded successfully.';
+        } catch (RuntimeException $e) {
+            throw $e;
+        }
+
+        return $uploadFile;
+    }
+}

--- a/src/Model/Entity/Biditem.php
+++ b/src/Model/Entity/Biditem.php
@@ -31,6 +31,7 @@ class Biditem extends Entity
     protected $_accessible = [
         'user_id' => true,
         'name' => true,
+        'file_name' => true,
         'finished' => true,
         'endtime' => true,
         'created' => true,

--- a/src/Model/Table/BiditemsTable.php
+++ b/src/Model/Table/BiditemsTable.php
@@ -73,6 +73,11 @@ class BiditemsTable extends Table
             ->notEmptyString('name');
 
         $validator
+            ->scalar('file_name')
+            ->maxLength('file_name', 100)
+            ->allowEmptyString('file_name', null, 'create');
+
+        $validator
             ->boolean('finished')
             ->requirePresence('finished', 'create')
             ->notEmptyString('finished');

--- a/src/Template/auction/add.ctp
+++ b/src/Template/auction/add.ctp
@@ -1,11 +1,12 @@
 <h2>商品を出品する</h2>
-<?= $this->Form->create($biditem) ?>
+<?= $this->Form->create($biditem, ['type' => 'file']) ?>
 <fieldset>
   <legend>※商品名と終了日時を入力：</legend>
   <?php
     echo $this->Form->hidden('user_id', ['value' => $authuser['id']]);
     echo '<p><strong>USER: ' . $authuser['username'] . '</strong></p>';
     echo $this->Form->control('name');
+    echo $this->Form->file('file_name');
     echo $this->Form->hidden('finished', ['value' => 0]);
     echo $this->Form->control('endtime');
     ?>

--- a/src/Template/auction/index.ctp
+++ b/src/Template/auction/index.ctp
@@ -3,6 +3,7 @@
 <table cellpadding="0" cellspacing="0">
 <thead>
 <tr>
+<th scope="col"></th>
 <th class="main" scope="col"><?= $this->Paginator->sort('name') ?></th>
 <th scope="col"><?= $this->Paginator->sort('finished') ?></th>
 <th scope="col"><?= $this->Paginator->sort('endtime') ?></th>
@@ -12,6 +13,7 @@
 <tbody>
 <?php foreach ($auction as $biditem) : ?>
 <tr>
+<td><?= $this->Html->image('../upimg/' . $biditem->file_name, array('width' => 200)) ?></td>
 <td><?= h($biditem->name) ?></td>
 <td><?= h($biditem->finished ? 'Finished':'') ?></td>
 <td><?= h($biditem->endtime) ?></td>

--- a/src/Template/auction/view.ctp
+++ b/src/Template/auction/view.ctp
@@ -1,6 +1,10 @@
 <h2>「<?=$biditem->name ?>」の情報</h2>
 <table class="vertical-table">
   <tr>
+    <th scope="row"></th>
+    <td><?=$this->Html->image('../upimg/' . $biditem->file_name, array('width' => 400)) ?></td>
+  </tr>
+  <tr>
     <th class="small" scope="row">出品者</th>
     <td><?= $biditem->has('user') ? $biditem->user->username : '' ?></td>
   </tr>


### PR DESCRIPTION
オークションサイトの出品登録ページで画像アップロードしてトップページ（商品リスト一覧）とViewページ（商品詳細）にアップロードした画像を表示するようにしました。


今回新たに学んだこと

・コンポーネントの作成
画像アップロードの部分をコンポーネントで作って、それをコントローラー側で使用しました。
https://book.cakephp.org/3/ja/controllers/components.html

・Htmlヘルパーでの画像表示。
HtmlHelper::image(string $path, array $options = array())
パラメータ: | $path (string) -- 画像のパス。$options (array) -- HTML属性 の配列
https://book.cakephp.org/2/ja/core-libraries/helpers/html.html

・コア定義定数
WWW_ROOT ウェブルートへのフルパス。
https://book.cakephp.org/3/ja/core-libraries/global-constants-and-functions.html


画像アップロード部分はPHPマニュアルを参考にしました。
https://www.php.net/manual/ja/features.file-upload.php