### PR TITLE
出品した商品の削除機能追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /logs/*
 /tmp/*
 /vendor/*
+/webroot/upimg/*
 
 # OS generated files #
 ######################

--- a/lesson-06-cakephp_データベース.txt
+++ b/lesson-06-cakephp_データベース.txt
@@ -29,6 +29,8 @@ created
 ==>Bidinfo
 (hasMany / Bidrequests) id : biditem_id
 ==>Bidrequests
+(hasMany / Bidmessages) id : biditem_id
+==>Bidmessages
 
 [Bidinfo]
 ・落札情報
@@ -61,6 +63,7 @@ created
 [Bidmessages]
 ・取引メッセージ
 id
+biditem_id
 bidinfo_id
 user_id
 message
@@ -68,6 +71,8 @@ created
 -
 (belongTo / Users) user_id : id
 ==>Users
+(belongTo / Biditems) biditem_id : id
+==>Biditems
 (belongTo / Bidinfo) bidinfo_id : id
 ==>Bidinfo
 

--- a/src/Controller/AuctionController.php
+++ b/src/Controller/AuctionController.php
@@ -197,4 +197,35 @@ class AuctionController extends AuctionBaseController
         ])->toArray();
         $this->set(compact('biditems'));
     }
+
+    /**
+     * Undocumented function
+     *
+     * @param [type] $id test
+     * @return mixed
+     */
+    public function delete($id = null)
+    {
+        $this->request->allowMethod(['post', 'delete']);
+        $biditem = $this->Biditems->get($id);
+        $dir = realpath(WWW_ROOT . "/upimg");
+        try {
+            $del_file = new File($dir . "/" . $biditem->file_name);
+            if ($del_file->delete()) {
+                $biditem['file'] = "";
+            } else {
+                throw new RuntimeException('ファイルの削除ができませんでした.');
+            }
+        } catch (RuntimeException $e) {
+            $this->log($e->getMessage(), LOG_DEBUG);
+            $this->log($biditem->file_name, LOG_DEBUG);
+        }
+        if ($this->Biditems->delete($biditem)) {
+            $this->Flash->success(__('商品を削除しました。'));
+        } else {
+            $this->Flash->error(__('商品の削除に失敗しました。;'));
+        }
+
+        return $this->redirect(['action' => 'index']);
+    }
 }

--- a/src/Controller/Component/UploadImageComponent.php
+++ b/src/Controller/Component/UploadImageComponent.php
@@ -1,0 +1,86 @@
+<?php
+namespace App\Controller\Component;
+
+use Cake\Controller\Component;
+use Cake\Filesystem\File;
+use RuntimeException;
+
+class UploadImageComponent extends Component
+{
+    /**
+     * Undocumented function
+     *
+     * @param [type] $file アップロードしたファイル情報
+     * @param [type] $dir ファイルを保存するフォルダ
+     * @param [type] $limitFileSize 保存出来るファイルサイズの最大値
+     * @return mixed
+     */
+    public function fileUpload($file = null, $dir = null, $limitFileSize = 1024 * 1024)
+    {
+        try {
+            // ファイルを保存するフォルダ $dirの値のチェック
+            if ($dir) {
+                if (!file_exists($dir)) {
+                    throw new RuntimeException('指定のディレクトリがありません。');
+                }
+            } else {
+                throw new RuntimeException('ディレクトリの指定がありません。');
+            }
+
+            // 未定義、複数ファイル、破損攻撃のいずれかの場合は無効処理
+            if (!isset($file['error']) || is_array($file['error'])) {
+                throw new RuntimeException('Invalid parameters.');
+            }
+
+            // エラーのチェック
+            switch ($file['error']) {
+                case 0:
+                    break;
+                case UPLOAD_ERR_OK:
+                    break;
+                case UPLOAD_ERR_NO_FILE:
+                    throw new RuntimeException('No file sent.');
+                case UPLOAD_ERR_INI_SIZE:
+                case UPLOAD_ERR_FORM_SIZE:
+                    throw new RuntimeException('Exceeded filesize limit.');
+                default:
+                    throw new RuntimeException('Unknown errors.');
+            }
+
+            // ファイル情報取得
+            $fileInfo = new File($file["tmp_name"]);
+
+            // ファイルサイズのチェック
+            if ($fileInfo->size() > $limitFileSize) {
+                throw new RuntimeException('Exceeded filesize limit.');
+            }
+
+            // ファイルタイプのチェックし、拡張子を取得
+            if (false === $ext = array_search(
+                $fileInfo->mime(),
+                ['jpg' => 'image/jpeg',
+                'png' => 'image/png',
+                'gif' => 'image/gif', ],
+                true
+            )) {
+                throw new RuntimeException('Invalid file format.');
+            }
+
+            // ファイル名の生成
+            // sha1_file()でハッシュ化
+            $uploadFile = sha1_file($file["tmp_name"]) . "." . $ext;
+
+            // ファイルの移動
+            if (!move_uploaded_file($file["tmp_name"], $dir . "/" . $uploadFile)) {
+                throw new RuntimeException('Failed to move uploaded file.');
+            }
+
+            // 処理を抜けたら正常終了
+            // echo 'File is uploaded successfully.';
+        } catch (RuntimeException $e) {
+            throw $e;
+        }
+
+        return $uploadFile;
+    }
+}

--- a/src/Model/Entity/Biditem.php
+++ b/src/Model/Entity/Biditem.php
@@ -31,6 +31,7 @@ class Biditem extends Entity
     protected $_accessible = [
         'user_id' => true,
         'name' => true,
+        'file_name' => true,
         'finished' => true,
         'endtime' => true,
         'created' => true,

--- a/src/Model/Entity/Bidmessage.php
+++ b/src/Model/Entity/Bidmessage.php
@@ -27,6 +27,7 @@ class Bidmessage extends Entity
      * @var array
      */
     protected $_accessible = [
+        'biditem_id' => true,
         'bidinfo_id' => true,
         'user_id' => true,
         'message' => true,

--- a/src/Model/Table/BiditemsTable.php
+++ b/src/Model/Table/BiditemsTable.php
@@ -47,10 +47,16 @@ class BiditemsTable extends Table
             'joinType' => 'INNER'
         ]);
         $this->hasOne('Bidinfo', [
-            'foreignKey' => 'biditem_id'
+            'foreignKey' => 'biditem_id',
+            'dependent' => true
         ]);
         $this->hasMany('Bidrequests', [
-            'foreignKey' => 'biditem_id'
+            'foreignKey' => 'biditem_id',
+            'dependent' => true
+        ]);
+        $this->hasMany('Bidmessages', [
+            'foreignKey' => 'biditem_id',
+            'dependent' => true
         ]);
     }
 

--- a/src/Model/Table/BiditemsTable.php
+++ b/src/Model/Table/BiditemsTable.php
@@ -73,6 +73,11 @@ class BiditemsTable extends Table
             ->notEmptyString('name');
 
         $validator
+            ->scalar('file_name')
+            ->maxLength('file_name', 100)
+            ->allowEmptyString('file_name', null, 'create');
+
+        $validator
             ->boolean('finished')
             ->requirePresence('finished', 'create')
             ->notEmptyString('finished');

--- a/src/Model/Table/BidmessagesTable.php
+++ b/src/Model/Table/BidmessagesTable.php
@@ -41,6 +41,10 @@ class BidmessagesTable extends Table
 
         $this->addBehavior('Timestamp');
 
+        $this->belongsTo('Biditems', [
+            'foreignKey' => 'biditem_id',
+            'joinType' => 'INNER'
+        ]);
         $this->belongsTo('Bidinfo', [
             'foreignKey' => 'bidinfo_id',
             'joinType' => 'INNER'
@@ -80,6 +84,7 @@ class BidmessagesTable extends Table
      */
     public function buildRules(RulesChecker $rules)
     {
+        $rules->add($rules->existsIn(['biditem_id'], 'Biditems'));
         $rules->add($rules->existsIn(['bidinfo_id'], 'Bidinfo'));
         $rules->add($rules->existsIn(['user_id'], 'Users'));
 

--- a/src/Template/auction/add.ctp
+++ b/src/Template/auction/add.ctp
@@ -1,11 +1,12 @@
 <h2>商品を出品する</h2>
-<?= $this->Form->create($biditem) ?>
+<?= $this->Form->create($biditem, ['type' => 'file']) ?>
 <fieldset>
   <legend>※商品名と終了日時を入力：</legend>
   <?php
     echo $this->Form->hidden('user_id', ['value' => $authuser['id']]);
     echo '<p><strong>USER: ' . $authuser['username'] . '</strong></p>';
     echo $this->Form->control('name');
+    echo $this->Form->file('file_name');
     echo $this->Form->hidden('finished', ['value' => 0]);
     echo $this->Form->control('endtime');
     ?>

--- a/src/Template/auction/index.ctp
+++ b/src/Template/auction/index.ctp
@@ -3,6 +3,7 @@
 <table cellpadding="0" cellspacing="0">
 <thead>
 <tr>
+<th scope="col"></th>
 <th class="main" scope="col"><?= $this->Paginator->sort('name') ?></th>
 <th scope="col"><?= $this->Paginator->sort('finished') ?></th>
 <th scope="col"><?= $this->Paginator->sort('endtime') ?></th>
@@ -12,6 +13,7 @@
 <tbody>
 <?php foreach ($auction as $biditem) : ?>
 <tr>
+<td><?= $this->Html->image('../upimg/' . $biditem->file_name, array('width' => 200)) ?></td>
 <td><?= h($biditem->name) ?></td>
 <td><?= h($biditem->finished ? 'Finished':'') ?></td>
 <td><?= h($biditem->endtime) ?></td>

--- a/src/Template/auction/index.ctp
+++ b/src/Template/auction/index.ctp
@@ -1,5 +1,6 @@
 <h2>ミニオークション！</h2>
 <h3>※出品されている商品</h3>
+<p><?= $this->Paginator->counter(['format' => '全{{pages}}ページ中{{page}}ページ目を表示しています']) ?></p>
 <table cellpadding="0" cellspacing="0">
 <thead>
 <tr>
@@ -19,6 +20,9 @@
 <td><?= h($biditem->endtime) ?></td>
 <td class="actions">
     <?= $this->Html->link(__('View'), ['action' => 'view', $biditem->id]) ?>
+    <?php if ($authuser['id'] === $biditem->user_id): ?>
+    <?= $this->Form->postLink(__('Delete'), ['action' => 'delete', $biditem->id], ['confirm' => '削除します。よろしいですか？']) ?>
+    <?php endif; ?>
 </td>
 </tr>
 <?php endforeach; ?>

--- a/src/Template/auction/msg.ctp
+++ b/src/Template/auction/msg.ctp
@@ -3,6 +3,7 @@
   <h3>※メッセージ情報</h3>
   <h6>※メッセージを送信する</h6>
   <?= $this->Form->create($bidmsg) ?>
+  <?= $this->Form->hidden('biditem_id', ['value' => $bidinfo->biditem_id]) ?>
   <?= $this->Form->hidden('bidinfo_id', ['value' => $bidinfo->id]) ?>
   <?= $this->Form->hidden('user_id', ['value' => $authuser['id']]) ?>
   <?= $this->Form->textarea('message', ['rows' => 2]) ?>

--- a/src/Template/auction/view.ctp
+++ b/src/Template/auction/view.ctp
@@ -1,6 +1,10 @@
 <h2>「<?=$biditem->name ?>」の情報</h2>
 <table class="vertical-table">
   <tr>
+    <th scope="row"></th>
+    <td><?=$this->Html->image('../upimg/' . $biditem->file_name, array('width' => 400)) ?></td>
+  </tr>
+  <tr>
     <th class="small" scope="row">出品者</th>
     <td><?= $biditem->has('user') ? $biditem->user->username : '' ?></td>
   </tr>


### PR DESCRIPTION
オークションサイトのトップページ（商品リスト一覧）に出品した商品の削除機能を追加しました。
商品を削除すると、同時に関連した落札情報、入札情報、取引メッセージ、ローカルに保存した画像も削除されるようにしました。

今回新たに学んだこと

・連鎖削除
エンティティーを削除するとき関連データを削除するようにしました。
https://book.cakephp.org/3/ja/orm/deleting-data.html

・Fileクラス
Fileクラスで削除処理対象の画像ファイルを指定しました。
https://book.cakephp.org/3/ja/core-libraries/file-folder.html